### PR TITLE
Descriptive error if path_settings is not valid

### DIFF
--- a/APP/CORE/CMS/core_settings.php
+++ b/APP/CORE/CMS/core_settings.php
@@ -103,7 +103,7 @@
 	// SITE settings
 	
 	if (!isPath($path_settings)) {
-		exit('1100CC');
+		exit('path_settings is not a valid path: '.$path_settings);
 	}
 	
 	require($path_settings);


### PR DESCRIPTION
Add a useful and more descriptive error if $path_settings is not a valid path, make debugging an installation much simpler